### PR TITLE
Style: Insert a blank line in the EOF

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -106,6 +106,7 @@ IndentExternBlock: AfterExternBlock
 IndentRequires:  false
 IndentWidth:     4
 IndentWrappedFunctionNames: false
+InsertNewLineAtEOF: true
 InsertTrailingCommas: None
 JavaScriptQuotes: Leave
 JavaScriptWrapImports: true


### PR DESCRIPTION
+ Added '[InsertNewlineAtEOF: true](https://releases.llvm.org/16.0.0/tools/clang/docs/ClangFormatStyleOptions.html#insertnewlineateof)' to .clang-format 